### PR TITLE
fix: 修复 PM2.5 数据映射问题，统一使用 pm2p5 字段名

### DIFF
--- a/custom_components/heweather/heweather/const.py
+++ b/custom_components/heweather/heweather/const.py
@@ -16,7 +16,7 @@ DEFAULT_HOST = "devapi.qweather.com"
 
 CONF_DISASTERLEVEL = "disasterlevel"
 CONF_DISASTERMSG = "disastermsg"
-CONF_SENSOR_LIST = ["air","comf","cw","drsg","flu","sport","trav","uv","sunglass","guomin","liangshai","jiaotong","fangshai","kongtiao","disaster_warn","temprature","humidity","category","feelsLike","text","windDir","windScale","windSpeed","pressure","vis","cloud","dew","precip","qlty","level","primary","pm25","pm10","co","so2","no2","o3"]
+CONF_SENSOR_LIST = ["air","comf","cw","drsg","flu","sport","trav","uv","sunglass","guomin","liangshai","jiaotong","fangshai","kongtiao","disaster_warn","temprature","humidity","category","feelsLike","text","windDir","windScale","windSpeed","pressure","vis","cloud","dew","precip","qlty","level","primary","pm2p5","pm10","co","so2","no2","o3"]
 
 # config flow
 DEFAULT_AUTH_METHOD: str = "key"

--- a/custom_components/heweather/sensor.py
+++ b/custom_components/heweather/sensor.py
@@ -77,7 +77,7 @@ OPTIONS = {
     "primary": ["Heweather_primary", "空气质量的主要污染物", "mdi:weather-dust", " "],
     "category": ["Heweather_category", "空气质量指数级别", "mdi:walk", " "],
     "level": ["Heweather_level", "空气质量指数等级", "mdi:walk", " "],
-    "pm25": ["Heweather_pm25", "PM2.5", "mdi:walk", " "],
+    "pm2p5": ["Heweather_pm25", "PM2.5", "mdi:walk", " "],
     "pm10": ["Heweather_pm10", "PM10", "mdi:walk", " "],
     "no2": ["Heweather_no2", "二氧化氮", "mdi:emoticon-dead", " "],
     "so2": ["Heweather_so2", "二氧化硫", "mdi:emoticon-dead", " "],
@@ -275,8 +275,8 @@ class HeweatherWeatherSensor(Entity):
             self._state = self._weather_data.level
         elif self._type == "pm10":
             self._state = self._weather_data.pm10
-        elif self._type == "pm25":
-            self._state = self._weather_data.pm25
+        elif self._type == "pm2p5":
+            self._state = self._weather_data.pm2p5
         elif self._type == "no2":
             self._state = self._weather_data.no2
         elif self._type == "so2":
@@ -343,7 +343,7 @@ class HeweatherWeatherSensor(Entity):
             self._attributes["states"] = self._suggestion_data.jiaotong[1]
 
         # 设置污染物单位
-        pollutant_types = {"pm10", "pm25", "no2", "so2", "co", "o3", "no", "nmhc"}
+        pollutant_types = {"pm10", "pm2p5", "no2", "so2", "co", "o3", "no", "nmhc"}
         if self._type in pollutant_types:
             unit = getattr(self._weather_data, f"{self._type}_unit", None)
             if unit:
@@ -399,7 +399,7 @@ class WeatherData(object):
 
 
 
-        self._pm25 = None
+        self._pm2p5 = None
         self._no2 = None
         self._so2 = None
         self._co = None
@@ -408,7 +408,7 @@ class WeatherData(object):
         self._nmhc = None
         # 新 API 单位不固定，动态获取
         self._pm10_unit = None
-        self._pm25_unit = None
+        self._pm2p5_unit = None
         self._no2_unit = None
         self._so2_unit = None
         self._co_unit = None
@@ -495,13 +495,13 @@ class WeatherData(object):
         return self._dew
 
     @property
-    def pm25(self):
+    def pm2p5(self):
         """pm2.5"""
-        return self._pm25
+        return self._pm2p5
 
     @property
-    def pm25_unit(self):
-        return self._pm25_unit
+    def pm2p5_unit(self):
+        return self._pm2p5_unit
 
     @property
     def pm10(self):


### PR DESCRIPTION
- 将内部代码统一从 pm25 改为 pm2p5，与和风天气 API 字段名保持一致
- 修复了 PM2.5 传感器数据无法正确获取的问题
- 移除了字段名映射逻辑，代码更简洁
- 实体名称保持 Heweather_pm25 不变
- 传感器名称从 pm25 改为 pm2p5