### PR TITLE
fix: JWT 补上必需的 iss 声明，并让接口异常可读（修复 #67 #61 #62）

### DIFF
--- a/custom_components/heweather/config_flow.py
+++ b/custom_components/heweather/config_flow.py
@@ -20,6 +20,7 @@ from .heweather.const import (
     CONF_STORAGE_PATH,
     CONF_JWT_SUB,
     CONF_JWT_KID,
+    CONF_JWT_ISS,
     CONF_DISASTERLEVEL,
     CONF_DISASTERMSG,
     CONF_SENSOR_LIST,
@@ -170,6 +171,7 @@ class HeWeatherConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     _jwt_pubkey: str
     _jwt_sub: str
     _jwt_kid: str
+    _jwt_iss: str
     _longitude: str
     _latitude: str
 
@@ -185,6 +187,7 @@ class HeWeatherConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._jwt_pubkey = ''
         self._jwt_sub = ''
         self._jwt_kid = ''
+        self._jwt_iss = ''
 
         self._longitude = ''
         self._latitude = ''
@@ -276,11 +279,14 @@ class HeWeatherConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 return await self.__show_auth_apikey_config_form("jwt_sub is empty")
             elif user_input.get("jwt_kid", None) == "":
                 return await self.__show_auth_apikey_config_form("jwt_kid is empty")
+            elif user_input.get("jwt_iss", None) == "":
+                return await self.__show_auth_apikey_config_form("jwt_iss is empty")
             elif user_input.get("host", None) == "":
                 return await self.__show_auth_apikey_config_form("host is empty")
             else:
                 self._jwt_sub = user_input.get("jwt_sub", self._jwt_sub)
                 self._jwt_kid = user_input.get("jwt_kid", self._jwt_kid)
+                self._jwt_iss = user_input.get("jwt_iss", self._jwt_iss)
                 self._host = user_input.get("host", self._host)
                 return await self.async_step_location_config()
         await self._heweather_cert.gen_key_async()
@@ -298,6 +304,10 @@ class HeWeatherConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 vol.Required(
                     "jwt_kid",
                     default=self._jwt_kid
+                ): str,
+                vol.Required(
+                    "jwt_iss",
+                    default=self._jwt_iss
                 ): str,
                 vol.Required(
                     "host",
@@ -384,6 +394,7 @@ class HeWeatherConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 CONF_STORAGE_PATH: self._storage_path,
                 CONF_JWT_SUB: self._jwt_sub,
                 CONF_JWT_KID: self._jwt_kid,
+                CONF_JWT_ISS: self._jwt_iss,
                 CONF_HOST: self._host,
                 CONF_LONGITUDE: self._longitude,
                 CONF_LATITUDE: self._latitude,
@@ -407,6 +418,7 @@ class HeWeatherOptionsFlow(config_entries.OptionsFlow):
         self._host = config_entry.data.get(CONF_HOST, DEFAULT_HOST)
         self._jwt_sub = config_entry.data.get(CONF_JWT_SUB, "")
         self._jwt_kid = config_entry.data.get(CONF_JWT_KID, "")
+        self._jwt_iss = config_entry.data.get(CONF_JWT_ISS, "")
         
         # Initialize location and disaster config
         self._longitude = config_entry.data.get(CONF_LONGITUDE, "")
@@ -498,6 +510,13 @@ class HeWeatherOptionsFlow(config_entries.OptionsFlow):
                     description_placeholders={"jwt_pubkey": self._jwt_pubkey},
                     errors={"base": "jwt_kid is empty"}
                 )
+            if not user_input.get("jwt_iss", "").strip():
+                return self.async_show_form(
+                    step_id="auth_jwt_config",
+                    data_schema=self._get_jwt_schema(),
+                    description_placeholders={"jwt_pubkey": self._jwt_pubkey},
+                    errors={"base": "jwt_iss is empty"}
+                )
             if not user_input.get("host", "").strip():
                 return self.async_show_form(
                     step_id="auth_jwt_config",
@@ -509,6 +528,7 @@ class HeWeatherOptionsFlow(config_entries.OptionsFlow):
             # Store auth data and proceed to location config
             self._jwt_sub = user_input.get("jwt_sub", "")
             self._jwt_kid = user_input.get("jwt_kid", "")
+            self._jwt_iss = user_input.get("jwt_iss", "")
             self._host = user_input.get("host", DEFAULT_HOST)
             return await self.async_step_location_config()
 
@@ -543,6 +563,7 @@ class HeWeatherOptionsFlow(config_entries.OptionsFlow):
         """Get JWT configuration schema."""
         current_jwt_sub = self._config_entry.data.get(CONF_JWT_SUB, "")
         current_jwt_kid = self._config_entry.data.get(CONF_JWT_KID, "")
+        current_jwt_iss = self._config_entry.data.get(CONF_JWT_ISS, "")
         current_host = self._config_entry.data.get(CONF_HOST, DEFAULT_HOST)
         
         return vol.Schema({
@@ -553,6 +574,10 @@ class HeWeatherOptionsFlow(config_entries.OptionsFlow):
             vol.Required(
                 "jwt_kid",
                 default=current_jwt_kid
+            ): str,
+            vol.Required(
+                "jwt_iss",
+                default=current_jwt_iss
             ): str,
             vol.Required(
                 "host",
@@ -671,6 +696,7 @@ class HeWeatherOptionsFlow(config_entries.OptionsFlow):
                 CONF_HOST: self._host,
                 CONF_JWT_SUB: self._config_entry.data.get(CONF_JWT_SUB, ""),
                 CONF_JWT_KID: self._config_entry.data.get(CONF_JWT_KID, ""),
+                CONF_JWT_ISS: self._config_entry.data.get(CONF_JWT_ISS, ""),
             })
         else:
             # Update JWT settings, preserve existing API key settings
@@ -679,6 +705,7 @@ class HeWeatherOptionsFlow(config_entries.OptionsFlow):
                 CONF_HOST: self._host,
                 CONF_JWT_SUB: self._jwt_sub,
                 CONF_JWT_KID: self._jwt_kid,
+                CONF_JWT_ISS: self._jwt_iss,
             })
 
         # Migrate entities if location changed (更平滑的实体迁移)

--- a/custom_components/heweather/heweather/const.py
+++ b/custom_components/heweather/heweather/const.py
@@ -11,6 +11,7 @@ CONF_KEY = "key"
 CONF_STORAGE_PATH = "storage_path"
 CONF_JWT_SUB = "auth_jwt_sub"
 CONF_JWT_KID = "auth_jwt_kid"
+CONF_JWT_ISS = "auth_jwt_iss"
 
 DEFAULT_HOST = "devapi.qweather.com"
 

--- a/custom_components/heweather/heweather/heweather_cert.py
+++ b/custom_components/heweather/heweather/heweather_cert.py
@@ -261,24 +261,28 @@ class HeWeatherCert:
             return None
 
     def get_jwt_token_heweather(
-        self, sub: str, kid: str, iat: int, exp: int
+        self, sub: str, kid: str, iat: int, exp: int, iss: str | None = None
     ) -> str | None:
         payload = {
             "iat": iat,
             "exp": exp,
             "sub": sub,
         }
+        if iss:
+            payload["iss"] = iss
         headers = {"kid": kid}
         return self.get_jwt_token(payload, headers)
 
     async def get_jwt_token_heweather_async(
-        self, sub: str, kid: str, iat: int, exp: int
+        self, sub: str, kid: str, iat: int, exp: int, iss: str | None = None
     ) -> str | None:
         payload = {
             "iat": iat,
             "exp": exp,
             "sub": sub,
         }
+        if iss:
+            payload["iss"] = iss
         headers = {"kid": kid}
         return await self.get_jwt_token_async(payload, headers)
 

--- a/custom_components/heweather/manifest.json
+++ b/custom_components/heweather/manifest.json
@@ -11,6 +11,6 @@
       "cryptography",
       "PyJWT"
     ],
-    "version":"2.4.7"
+    "version":"2.4.8"
   }
   

--- a/custom_components/heweather/sensor.py
+++ b/custom_components/heweather/sensor.py
@@ -46,6 +46,7 @@ from .heweather.const import (
     CONF_KEY,
     CONF_JWT_SUB,
     CONF_JWT_KID,
+    CONF_JWT_ISS,
     DEFAULT_HOST,
     CONF_DISASTERLEVEL,
     CONF_DISASTERMSG,
@@ -139,8 +140,9 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
         heweather_cert = hass.data[DOMAIN].get('heweather_cert', None)
         jwt_sub = config_entry.data.get(CONF_JWT_SUB)
         jwt_kid = config_entry.data.get(CONF_JWT_KID)
-        suggestion_data = SuggestionData(hass, longitude, latitude, host, heweather_cert=heweather_cert, jwt_sub=jwt_sub, jwt_kid=jwt_kid)
-        weather_data = WeatherData(hass, longitude, latitude, host, disastermsg, disasterlevel, heweather_cert=heweather_cert, jwt_sub=jwt_sub, jwt_kid=jwt_kid)
+        jwt_iss = config_entry.data.get(CONF_JWT_ISS)
+        suggestion_data = SuggestionData(hass, longitude, latitude, host, heweather_cert=heweather_cert, jwt_sub=jwt_sub, jwt_kid=jwt_kid, jwt_iss=jwt_iss)
+        weather_data = WeatherData(hass, longitude, latitude, host, disastermsg, disasterlevel, heweather_cert=heweather_cert, jwt_sub=jwt_sub, jwt_kid=jwt_kid, jwt_iss=jwt_iss)
 
     await weather_data.async_update(dt_util.now())
     config_entry.async_on_unload(async_track_time_interval(hass, weather_data.async_update, WEATHER_TIME_BETWEEN_UPDATES, cancel_on_shutdown=True))
@@ -374,7 +376,7 @@ class HeweatherWeatherSensor(Entity):
 class WeatherData(object):
     """天气相关的数据，存储在这个类中."""
 
-    def __init__(self, hass, longitude, latitude, host, disastermsg, disasterlevel, key=None, heweather_cert=None, jwt_sub=None, jwt_kid=None):
+    def __init__(self, hass, longitude, latitude, host, disastermsg, disasterlevel, key=None, heweather_cert=None, jwt_sub=None, jwt_kid=None, jwt_iss=None):
         """初始化函数."""
         self._hass = hass
         location = f"{longitude},{latitude}"
@@ -401,6 +403,7 @@ class WeatherData(object):
             self._heweather_cert = heweather_cert
             self._jwt_sub = jwt_sub
             self._jwt_kid = jwt_kid
+            self._jwt_iss = jwt_iss
 
         self._feelsLike = None
         self._text = None
@@ -616,11 +619,17 @@ class WeatherData(object):
             connector = aiohttp.TCPConnector(limit=10)
             headers = None
             if self._is_jwt:
-                jwt_token = await self._heweather_cert.get_jwt_token_heweather_async(self._jwt_sub, self._jwt_kid, int(time.time()) - 30, int(time.time()) + 180)
+                jwt_token = await self._heweather_cert.get_jwt_token_heweather_async(self._jwt_sub, self._jwt_kid, int(time.time()) - 30, int(time.time()) + 180, self._jwt_iss)
                 headers = {'Authorization': f'Bearer {jwt_token}'}
             async with aiohttp.ClientSession(connector=connector, timeout=timeout, headers=headers) as session:
                 async with session.get(self._weather_now_url) as response:
                     json_data = await response.json()
+                    if "now" not in json_data:
+                        _LOGGER.error(
+                            "Unexpected response from %s (HTTP %s): %s",
+                            self._weather_now_url, response.status, json_data
+                        )
+                        return
                     weather = json_data["now"]
                 async with session.get(self._air_now_url) as response:
                     json_data = await response.json()
@@ -699,7 +708,7 @@ class WeatherData(object):
 class SuggestionData(object):
     """天气相关建议的数据，存储在这个类中."""
 
-    def __init__(self, hass, longitude, latitude, host, key=None, heweather_cert=None, jwt_sub=None, jwt_kid=None):
+    def __init__(self, hass, longitude, latitude, host, key=None, heweather_cert=None, jwt_sub=None, jwt_kid=None, jwt_iss=None):
         """初始化函数."""
         self._hass = hass
         location = f"{longitude},{latitude}"
@@ -720,6 +729,7 @@ class SuggestionData(object):
             self._heweather_cert = heweather_cert
             self._jwt_sub = jwt_sub
             self._jwt_kid = jwt_kid
+            self._jwt_iss = jwt_iss
 
         self._updatetime = ["1","1"]
         self._air = ["1","1"]
@@ -820,7 +830,7 @@ class SuggestionData(object):
             session = async_get_clientsession(self._hass)
             headers = None
             if self._is_jwt:
-                jwt_token = await self._heweather_cert.get_jwt_token_heweather_async(self._jwt_sub, self._jwt_kid, int(time.time()) - 30, int(time.time()) + 180)
+                jwt_token = await self._heweather_cert.get_jwt_token_heweather_async(self._jwt_sub, self._jwt_kid, int(time.time()) - 30, int(time.time()) + 180, self._jwt_iss)
                 headers = {'Authorization': f'Bearer {jwt_token}'}
             with async_timeout.timeout(15):
             #with async_timeout.timeout(15, loop=self._hass.loop):

--- a/custom_components/heweather/translations/en.json
+++ b/custom_components/heweather/translations/en.json
@@ -134,7 +134,8 @@
             "key is empty": "key is empty",
             "host is empty": "host is empty",
             "jwt_sub is empty": "jwt_sub is empty",
-            "jwt_kid is empty": "jwt_kid is empty"
+            "jwt_kid is empty": "jwt_kid is empty",
+            "jwt_iss is empty": "jwt_iss is empty"
         },
         "flow_title": "heweather",
         "step": {
@@ -155,10 +156,11 @@
             },
             "auth_jwt_config": {
                 "title": "JWT config",
-                "description": "Please upload the public key\n```\n{jwt_pubkey}\n```\n to the QWeather developer console, then enter the corresponding Project ID, Credential ID, and API Host.",
+                "description": "Please upload the public key\n```\n{jwt_pubkey}\n```\n to the QWeather developer console, then enter the corresponding Project ID, Credential ID, Developer ID, and API Host.",
                 "data": {
                     "jwt_sub": "Project ID",
                     "jwt_kid": "Credential ID",
+                    "jwt_iss": "Developer ID",
                     "host": "API Host"
                 }
             },
@@ -188,7 +190,8 @@
             "key is empty": "key is empty",
             "host is empty": "host is empty",
             "jwt_sub is empty": "jwt_sub is empty",
-            "jwt_kid is empty": "jwt_kid is empty"
+            "jwt_kid is empty": "jwt_kid is empty",
+            "jwt_iss is empty": "jwt_iss is empty"
         },
         "step": {
             "auth_method_config": {
@@ -208,10 +211,11 @@
             },
             "auth_jwt_config": {
                 "title": "Update JWT config",
-                "description": "Please upload the public key\n```\n{jwt_pubkey}\n```\n to the QWeather developer console, then enter the corresponding Project ID, Credential ID, and API Host.",
+                "description": "Please upload the public key\n```\n{jwt_pubkey}\n```\n to the QWeather developer console, then enter the corresponding Project ID, Credential ID, Developer ID, and API Host.",
                 "data": {
                     "jwt_sub": "Project ID",
                     "jwt_kid": "Credential ID",
+                    "jwt_iss": "Developer ID",
                     "host": "API Host"
                 }
             },

--- a/custom_components/heweather/translations/zh-Hans.json
+++ b/custom_components/heweather/translations/zh-Hans.json
@@ -134,7 +134,8 @@
             "key is empty": "API KEY不能为空",
             "host is empty": "API Host不能为空",
             "jwt_sub is empty": "项目ID不能为空",
-            "jwt_kid is empty": "凭据ID不能为空"
+            "jwt_kid is empty": "凭据ID不能为空",
+            "jwt_iss is empty": "开发者ID不能为空"
         },
         "flow_title": "和风天气",
         "step": {
@@ -155,10 +156,11 @@
             },
             "auth_jwt_config": {
                 "title": "JWT认证",
-                "description": "请将公钥\n```\n{jwt_pubkey}\n```\n上传至和风天气开发控制台，并输入对应的项目ID、凭据ID和API Host。",
+                "description": "请将公钥\n```\n{jwt_pubkey}\n```\n上传至和风天气开发控制台，并输入对应的项目ID、凭据ID、开发者ID和API Host。",
                 "data": {
                     "jwt_sub": "项目ID",
                     "jwt_kid": "凭据ID",
+                    "jwt_iss": "开发者ID",
                     "host": "API Host"
                 }
             },
@@ -188,7 +190,8 @@
             "key is empty": "API KEY不能为空",
             "host is empty": "API Host不能为空",
             "jwt_sub is empty": "项目ID不能为空",
-            "jwt_kid is empty": "凭据ID不能为空"
+            "jwt_kid is empty": "凭据ID不能为空",
+            "jwt_iss is empty": "开发者ID不能为空"
         },
         "step": {
             "auth_method_config": {
@@ -208,10 +211,11 @@
             },
             "auth_jwt_config": {
                 "title": "更新JWT认证",
-                "description": "请将公钥\n```\n{jwt_pubkey}\n```\n上传至和风天气开发控制台，并输入对应的项目ID、凭据ID和API Host。",
+                "description": "请将公钥\n```\n{jwt_pubkey}\n```\n上传至和风天气开发控制台，并输入对应的项目ID、凭据ID、开发者ID和API Host。",
                 "data": {
                     "jwt_sub": "项目ID",
                     "jwt_kid": "凭据ID",
+                    "jwt_iss": "开发者ID",
                     "host": "API Host"
                 }
             },

--- a/custom_components/heweather/weather.py
+++ b/custom_components/heweather/weather.py
@@ -54,6 +54,7 @@ from .heweather.const import (
     CONF_KEY,
     CONF_JWT_SUB,
     CONF_JWT_KID,
+    CONF_JWT_ISS,
     DEFAULT_HOST,
     CONDITION_CLASSES,
     ATTR_UPDATE_TIME,
@@ -125,7 +126,8 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
         heweather_cert = hass.data[DOMAIN].get('heweather_cert', None)
         jwt_sub = config_entry.data.get(CONF_JWT_SUB)
         jwt_kid = config_entry.data.get(CONF_JWT_KID)
-        data = WeatherData(hass, longitude, latitude, host, heweather_cert=heweather_cert, jwt_sub=jwt_sub, jwt_kid=jwt_kid)
+        jwt_iss = config_entry.data.get(CONF_JWT_ISS)
+        data = WeatherData(hass, longitude, latitude, host, heweather_cert=heweather_cert, jwt_sub=jwt_sub, jwt_kid=jwt_kid, jwt_iss=jwt_iss)
 
     weather = HeWeather(data, longitude, latitude)
     await weather.async_update_data(dt_util.now())
@@ -369,7 +371,7 @@ class HeWeather(WeatherEntity):
 class WeatherData():
     """天气相关的数据，存储在这个类中."""
 
-    def __init__(self, hass, longitude, latitude, host, key=None, heweather_cert=None, jwt_sub=None, jwt_kid=None):
+    def __init__(self, hass, longitude, latitude, host, key=None, heweather_cert=None, jwt_sub=None, jwt_kid=None, jwt_iss=None):
         """初始化函数."""
         self._hass = hass
         location = f"{longitude},{latitude}"
@@ -390,6 +392,7 @@ class WeatherData():
             self._heweather_cert = heweather_cert
             self._jwt_sub = jwt_sub
             self._jwt_kid = jwt_kid
+            self._jwt_iss = jwt_iss
 
         #self._name = None
         self._condition = None
@@ -512,11 +515,17 @@ class WeatherData():
             connector = aiohttp.TCPConnector(limit=10)
             headers = None
             if self._is_jwt:
-                jwt_token = await self._heweather_cert.get_jwt_token_heweather_async(self._jwt_sub, self._jwt_kid, int(time.time()) - 30, int(time.time()) + 180)
+                jwt_token = await self._heweather_cert.get_jwt_token_heweather_async(self._jwt_sub, self._jwt_kid, int(time.time()) - 30, int(time.time()) + 180, self._jwt_iss)
                 headers = {'Authorization': f'Bearer {jwt_token}'}
             async with aiohttp.ClientSession(connector=connector, timeout=timeout, headers=headers) as session:
                 async with session.get(self._weather_now_url) as response:
                     json_data = await response.json()
+                    if "now" not in json_data:
+                        _LOGGER.error(
+                            "Unexpected response from %s (HTTP %s): %s",
+                            self._weather_now_url, response.status, json_data
+                        )
+                        return
                     weather = json_data["now"]
                 async with session.get(self._forecast_url) as response:
                     json_data = await response.json()


### PR DESCRIPTION
修复 #67，同时解决 #61 和 #62 报告的 `KeyError: 'now'`。

## 问题

和风要求 JWT 的 payload 携带 `iss`（开发者 ID），而 `get_jwt_token_heweather[_async]()` 只放了 `iat` / `exp` / `sub`，导致所有 JWT 请求被返回 **HTTP 401**。

401 的响应体中没有 `now` 字段，紧接着的 `json_data["now"]` 抛出 `KeyError: 'now'` —— 用户看到的是这个，真正的 401 完全不可见。

## 改动

**1. 补上 `iss` 声明**

- `const.py` 新增 `CONF_JWT_ISS`
- `heweather_cert.py` 的两个 `get_jwt_token_heweather*` 增加可选参数 `iss`，仅在有值时写入 payload
- 配置流程与选项流程的 JWT 步骤各增加一个「开发者ID」输入框，中英文案同步
- `weather.py` / `sensor.py` 从配置项读取并传递

因为 `iss` 只在非空时加入 payload，**API KEY 方式和既有配置都不受影响**；老用户在选项里补填开发者 ID 即可，无需重新配置。

**2. 接口异常可读化**

`weather.py` 与 `sensor.py` 中取 `now` 之前先判断字段是否存在，缺失时记录状态码与响应体后返回：

```
ERROR ... Unexpected response from https://<host>/v7/weather/now?location=... (HTTP 401):
{'error': {'status': 401, 'title': 'Unauthorized',
           'detail': 'Authentication failed, check your KEY/Token or Host.'}}
```

取代原先的 `KeyError: 'now'`。#61 / #62 悬了八个月没人定位，正是因为原始报错完全掩盖了真实原因。

## 验证

在真实环境（Home Assistant 2026.5.4 + 和风免费订阅）上完整跑过：

- 修改前：401，无任何实体
- 修改后：200，天气实体 + 23 个传感器全部有值，日志零报错
- 通过 HA 选项流 API 实测，JWT 步骤表单字段为 `['jwt_sub', 'jwt_kid', 'jwt_iss', 'host']`，提交后配置项正确写入 `auth_jwt_iss`
- 未填 `iss` 时（模拟旧配置），不再抛 KeyError，而是打印上面那条可读日志

版本号顺带升到 2.4.8。
